### PR TITLE
Rebuild for libnetcdf 4.6.2

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -12,8 +12,3 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
-libnetcdf:
-- 4.7.1
-pin_run_as_build:
-  libnetcdf:
-    max_pin: x.x.x

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -12,12 +12,7 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
-libnetcdf:
-- 4.7.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
-pin_run_as_build:
-  libnetcdf:
-    max_pin: x.x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 90e10191116a78228739276078a0ddcf0d6458516f192e9e79fecb2beeceb3fa
 
 build:
-  number: 6
+  number: 7
   skip: True  # [win] 
 
 requirements:
@@ -18,10 +18,10 @@ requirements:
     - {{ compiler('c') }}         # need gcc7 to link library
     - {{ compiler('fortran') }}   # (_gmalloc_fortran) issue without gfortran7
   host:
-    - libnetcdf 
+    - libnetcdf >=4.6.2,<4.6.3.0a0
     - g2clib
   run:
-    - libnetcdf 
+    - libnetcdf >=4.6.2,<4.6.3.0a0
     - g2clib
 
 test:


### PR DESCRIPTION
Linking to other libraries in other feedstocks suggests that the build happened with 4.7.1 even though the run is pinned to 4.6.2

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
